### PR TITLE
Support more Solidity keywords

### DIFF
--- a/Solidity.YAML-tmLanguage
+++ b/Solidity.YAML-tmLanguage
@@ -39,7 +39,7 @@ patterns:
 - match: \b(true|false)\b
   name: constant.language
   comment: True and false keywords
-- match: \b(var|import|function|constant|if|else|for|while|do|break|continue|returns?|private|public|internal|external|inherited|this|suicide|new|is|throw|revert|assert|require|\_)\b
+- match: \b(var|import|function|constant|view|pure|storage|memory|if|else|for|while|do|break|continue|returns?|private|public|internal|external|inherited|this|suicide|selfdestruct|new|is|throw|revert|assert|require|\_)\b
   name: keyword.control
   comment: Langauge keywords
 - match: \b([A-Za-z_]\w+)(\s+(?:private|public|internal|external|inherited))?\s+([A-Za-z_]\w*)\;

--- a/Solidity.tmLanguage
+++ b/Solidity.tmLanguage
@@ -125,7 +125,7 @@
 			<key>comment</key>
 			<string>Langauge keywords</string>
 			<key>match</key>
-			<string>\b(var|import|function|constant|if|else|for|while|do|break|continue|returns?|private|public|internal|external|inherited|this|suicide|new|is|throw|revert|assert|require|\_)\b</string>
+			<string>\b(var|import|function|constant|view|pure|storage|memory|if|else|for|while|do|break|continue|returns?|private|public|internal|external|inherited|this|suicide|selfdestruct|new|is|throw|revert|assert|require|\_)\b</string>
 			<key>name</key>
 			<string>keyword.control</string>
 		</dict>


### PR DESCRIPTION
Adds these keywords:

* `view` (added in Solidity 0.4.16, marks function as non-mutating)
* `pure` (added in Solidity 0.4.16, marks function as not accessing storage)
* `storage` (data location keyword)
* `memory` (data location keyword)
* `selfdestruct` (alias to `suicide`, the latter is now deprecated)