### PR TITLE
Add `emit` keyword

### DIFF
--- a/Solidity.YAML-tmLanguage
+++ b/Solidity.YAML-tmLanguage
@@ -39,7 +39,7 @@ patterns:
 - match: \b(true|false)\b
   name: constant.language
   comment: True and false keywords
-- match: \b(var|import|function|constant|view|pure|payable|storage|memory|if|else|for|while|do|break|continue|returns?|private|public|internal|external|inherited|this|suicide|selfdestruct|new|is|throw|revert|assert|require|\_)\b
+- match: \b(var|import|function|constant|view|pure|payable|storage|memory|if|else|for|while|do|break|continue|returns?|private|public|internal|external|inherited|this|suicide|selfdestruct|emit|new|is|throw|revert|assert|require|\_)\b
   name: keyword.control
   comment: Langauge keywords
 - match: \b([A-Za-z_]\w+)(\s+(?:private|public|internal|external|inherited))?\s+([A-Za-z_]\w*)\;

--- a/Solidity.tmLanguage
+++ b/Solidity.tmLanguage
@@ -125,7 +125,7 @@
 			<key>comment</key>
 			<string>Langauge keywords</string>
 			<key>match</key>
-			<string>\b(var|import|function|constant|view|pure|storage|memory|if|else|for|while|do|break|continue|returns?|private|public|internal|external|inherited|this|suicide|selfdestruct|new|is|throw|revert|assert|require|\_)\b</string>
+			<string>\b(var|import|function|constant|view|pure|storage|memory|if|else|for|while|do|break|continue|returns?|private|public|internal|external|inherited|this|suicide|selfdestruct|emit|new|is|throw|revert|assert|require|\_)\b</string>
 			<key>name</key>
 			<string>keyword.control</string>
 		</dict>


### PR DESCRIPTION
This adds `emit` keyword which is, since Solidity 0.4.21, the recommended way to emit events. Emitting events without using `emit` keyword will be deprecated in future. See these links for more details:

https://github.com/ethereum/solidity/issues/2877
https://medium.com/@aniketengg/emit-keyword-in-solidity-242a679b0e1a