### PR TITLE
Accept "address payable" as built-in type (to be introduced in solidity 0.5.0).

### DIFF
--- a/Solidity.YAML-tmLanguage
+++ b/Solidity.YAML-tmLanguage
@@ -24,7 +24,7 @@ patterns:
     '2': {name: entity.name.function}
     '3': {name: entity.name.function}
   comment: Structures, function, event definitions
-- match: \b(address|string|bytes?\d*|int\d*|uint\d*|bool|u?fixed\d+x\d+)\s*(?:\[(\d*)\])?\s*(?:\[(\d*)\])?\s*(?:(indexed|memory|storage|calldata)?\s*(\b[A-Za-z_]\w*)\s*)?(?=[,\)])
+- match: \b(address\s*payable|address|string|bytes?\d*|int\d*|uint\d*|bool|u?fixed\d+x\d+)\s*(?:\[(\d*)\])?\s*(?:\[(\d*)\])?\s*(?:(indexed|memory|storage|calldata|payable)?\s*(\b[A-Za-z_]\w*)\s*)?(?=[,\)])
   captures:
     '1': {name: constant.language}
     '2': {name: constant.numeric}
@@ -42,7 +42,7 @@ patterns:
 - match: \b(true|false)\b
   name: constant.language
   comment: True and false keywords
-- match: \b(address|string|bytes?\d*|int\d*|uint\d*|bool|u?fixed\d+x\d+)(?:\s*\[(\d*)\])?(?:\s*\[(\d*)\])?\s*(private|public|internal|external|constant|memory|storage)?\s+(?:[A-Za-z_]\w*)\s*[\;\=]
+- match: \b(address\s*payable|address|string|bytes?\d*|int\d*|uint\d*|bool|u?fixed\d+x\d+)(?:\s*\[(\d*)\])?(?:\s*\[(\d*)\])?\s*(private|public|internal|external|constant|memory|storage)?\s+(?:[A-Za-z_]\w*)\s*[\;\=]
 #- match: \b([A-Za-z_]\w+)(\s+(?:private|public|internal|external|constant))?\s+([A-Za-z_]\w*)[\;(?:\s*\=)]
   captures:
     '1': {name: constant.language}

--- a/Solidity.tmLanguage
+++ b/Solidity.tmLanguage
@@ -97,7 +97,7 @@
 			<key>comment</key>
 			<string>Built-in types</string>
 			<key>match</key>
-			<string>\b(address|string|bytes?\d*|int\d*|uint\d*|bool|u?fixed\d+x\d+)\s*(?:\[(\d*)\])?\s*(?:\[(\d*)\])?\s*(?:(indexed|memory|storage|calldata)?\s*(\b[A-Za-z_]\w*)\s*)?(?=[,\)])</string>
+			<string>\b(address\s*payable|address|string|bytes?\d*|int\d*|uint\d*|bool|u?fixed\d+x\d+)\s*(?:\[(\d*)\])?\s*(?:\[(\d*)\])?\s*(?:(indexed|memory|storage|calldata)?\s*(\b[A-Za-z_]\w*)\s*)?(?=[,\)])</string>
 		</dict>
 		<dict>
 			<key>captures</key>
@@ -163,7 +163,7 @@
 			<key>comment</key>
 			<string>Variable definitions - bytes data; | uint x = uint(y);</string>
 			<key>match</key>
-			<string>\b(address|string|bytes?\d*|int\d*|uint\d*|bool|u?fixed\d+x\d+)(?:\s*\[(\d*)\])?(?:\s*\[(\d*)\])?\s*(private|public|internal|external|constant|memory|storage)?\s+(?:[A-Za-z_]\w*)\s*[\;\=]</string>
+			<string>\b(address\s*payable|address|string|bytes?\d*|int\d*|uint\d*|bool|u?fixed\d+x\d+)(?:\s*\[(\d*)\])?(?:\s*\[(\d*)\])?\s*(private|public|internal|external|constant|memory|storage)?\s+(?:[A-Za-z_]\w*)\s*[\;\=]</string>
 		</dict>
 		<dict>
 			<key>comment</key>


### PR DESCRIPTION
In solidity 0.5.0 we introduce a new built-in type ``address payable`` (see https://github.com/ethereum/solidity/pull/4926), so syntax highlighting has to be adjusted accordingly.

I have little experience with writing sublime language packages and there may be a better way to handle this, but for me this PR seems to work. Also, I think it is fine and maybe even preferable to consider ``payable`` in ``address payable`` as part of the type and not the same as ``payable`` in ``function f() payable``, since they are conceptually different (``payable`` is indeed part of the type in ``address payable`` and for this new type ``payable`` always has to be directly after ``address``).

Thank you very much for having a look into this :)!