### PR TITLE
Add support for 'immutable'

### DIFF
--- a/Solidity.sublime-syntax
+++ b/Solidity.sublime-syntax
@@ -21,7 +21,7 @@ variables:
   func_modifier_override: override
 
   type: '(?:address\s*payable|address|string|bytes?\d*|int\d*|uint\d*|bool|u?fixed\d+x\d+)'
-  type_modifier: '(?:private|public|internal|external|constant|memory|storage)'
+  type_modifier: '(?:private|public|internal|external|constant|immutable|memory|storage)'
   custom_type: '(?:[A-Za-z_][\w\.]*)' # ex.: A.MyStruct
   attribute: '(?:indexed|memory|storage|calldata|payable)'
 


### PR DESCRIPTION
Solidity v0.6.5 [added the `immutable`](https://github.com/ethereum/solidity/releases/tag/v0.6.5) keyword, which is used [the same way `constant` is used](https://solidity.readthedocs.io/en/v0.6.8/contracts.html?#constant-and-immutable-state-variables). This PR adds highlighting for it.