### PR TITLE
Fix contract name selection regex in Solidity and Vyper

### DIFF
--- a/Solidity.sublime-syntax
+++ b/Solidity.sublime-syntax
@@ -193,13 +193,13 @@ contexts:
   # contract
 
   contract:
-    - match: \b({{contract_like}})(\s+{{identifier}})\s+(is)\b
+    - match: \b({{contract_like}})\s+({{identifier}})\s+(is)\b
       captures:
         1: keyword
         2: entity.name.class
         3: keyword
       push: contract-parents
-    - match: \b({{contract_like}})(\s+{{identifier}})\b
+    - match: \b({{contract_like}})\s+({{identifier}})\b
       captures:
         1: keyword
         2: entity.name.class

--- a/Vyper.sublime-syntax
+++ b/Vyper.sublime-syntax
@@ -108,7 +108,7 @@ contexts:
   # contract
 
   contract:
-    - match: \b({{contractlike}})(\s+{{identifier}})\b
+    - match: \b({{contractlike}})\s+({{identifier}})\b
       captures:
         1: keyword
         2: entity.name.class


### PR DESCRIPTION
The whitespaces before the contract name where erroneously selected with the contract name. Now only the contract name is selected.