### PR TITLE
Fix named-arguments matching logic.

### DIFF
--- a/Solidity.sublime-syntax
+++ b/Solidity.sublime-syntax
@@ -763,10 +763,6 @@ contexts:
         1: keyword
         2: punctuation.section.block.begin.sol
       push: function-call-arguments
-    - match: '({{special_accessors}})\s*\('
-      captures:
-        1: storage.type
-      push: function-call-arguments
     - match: '({{identifier}})\s*(\()'
     #- match: '({{identifier}})\s*(?:\{.*?\})?\s*(\()'
       captures:
@@ -800,8 +796,10 @@ contexts:
   function-call-named-arguments:
     - include: expression-include
     - match: ','
-    - match: '\}'
-      scope: punctuation.section.block.end.sol
+    - match: '(\})\s*(\()'
+      captures:
+        1: punctuation.section.block.end.sol
+        2: punctuation.section.block.begin.sol
       pop: true
     - match: \;
       pop: true
@@ -1229,8 +1227,8 @@ contexts:
     - match: '\b({{opcode}})\b'
       scope: storage.type
 
-  # function call
-  # ⚠️ keep in sync with assembly-call!
+  # assembly function call
+  # ⚠️ keep in sync with function-call!
   # let expected := mod(keccak256(0x2e0, sub(b, 0x2e0)), gen_order)
   #
   assembly-function-call:
@@ -1258,10 +1256,6 @@ contexts:
       captures:
         1: keyword
         2: punctuation.section.block.begin.sol
-      push: function-call-assembly-arguments
-    - match: '({{special_accessors}})\s*\('
-      captures:
-        1: storage.type
       push: function-call-assembly-arguments
     - match: '({{identifier}})\s*(\()'
       captures:


### PR DESCRIPTION
Previously it would think that the function arguments after the named arguments is the tuple-content (because the opening parenthesis would not be matched as part of the function call).

Also cleans up the this/super matching as part of a function[assembly] call as it is cannot be called directly.

The following example has broken syntax highlighting before this PR, and is good after:
```solidity
pragma solidity 0.8.9;

contract Example {
    function s() external {}

    function f() external returns (bool) {
        try this.s{gas: 100000}() {
            return true;
        } catch {
            return false;
        }
    }
}
```